### PR TITLE
fix for deleting dimension info

### DIFF
--- a/pyTEMlib/image_tools.py
+++ b/pyTEMlib/image_tools.py
@@ -515,12 +515,17 @@ def rigid_registration(dataset):
     rigid_registered.source = dataset.title
     rigid_registered.metadata = {'analysis': 'rigid sub-pixel registration', 'drift': drift,
                                  'input_crop': input_crop, 'input_shape': dataset.shape[1:]}
-    if hasattr(rigid_registered, 'z'):
-        del rigid_registered.z
-    if hasattr(rigid_registered, 'x'):
-        del rigid_registered.x
-    if hasattr(rigid_registered, 'y'):
-        del rigid_registered.y
+    #if hasattr(rigid_registered, 'z'):
+    #    del rigid_registered.z
+    #if hasattr(rigid_registered, 'x'):
+    #    del rigid_registered.x
+    #if hasattr(rigid_registered, 'y'):
+    #    del rigid_registered.y
+
+    rigid_registered.del_dimension(0)
+    rigid_registered.del_dimension(1)
+    rigid_registered.del_dimension(2)
+
     # rigid_registered._axes = {}
     rigid_registered.set_dimension(0, dataset._axes[frame_dim[0]])
     rigid_registered.set_dimension(1, dataset._axes[spatial_dim[0]][input_crop[0]:input_crop[1]])


### PR DESCRIPTION
This fixes the deletion of dimensions in the demon registration. However, the image registration functions are in px. So there is a choice to either accept this pull request, or deprecate and remove the image reg functions from pyTEMLib.